### PR TITLE
Dont change folder icons

### DIFF
--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -17,9 +17,13 @@ const update = () => {
     for (let i = 0; i < filenameDomsLength; i += 1) {
       const { innerText: filename } = filenameDoms[i];
       const iconDom = iconDoms[i];
+
+      const oldIcon = iconDom.querySelector('.octicon');
+      const isDirectory = oldIcon.classList.contains('octicon-file-directory');
+
       const className = fileIcons.getClassWithColor(filename);
 
-      if (className) {
+      if (className && !isDirectory) {
         iconDom.innerHTML = `<span class='${className}'></span>`;
       }
     }


### PR DESCRIPTION
Checks to see if a icon is a folder before changing it to a new icon.

Closes #12.