### PR TITLE
Remove ton of `eval` from build when `NODE_ENV` is `development`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "version": "0.2.1",
   "scripts": {
-    "build": "node utils/build.js",
+    "build": "cross-env NODE_ENV=production node utils/build.js",
     "precommit": "lint-staged",
     "lint": "eslint src",
     "lint:fix": "npm run lint -- --fix",
@@ -36,6 +36,7 @@
     "babel-preset-env": "^1.6.1",
     "clean-webpack-plugin": "^0.1.17",
     "copy-webpack-plugin": "^4.3.1",
+    "cross-env": "^5.1.3",
     "css-loader": "^0.25.0",
     "eslint": "^4.14.0",
     "eslint-config-airbnb": "^16.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1565,6 +1565,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.3.tgz#f8ae18faac87692b0a8b4d2f7000d4ec3a85dfd7"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -3454,6 +3461,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
 is-wsl@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
**(Probably)** Fix #19.

I use [`cross-env`](https://github.com/kentcdodds/cross-env) to set `NODE_ENV` to `production` when you build.

It will remove ton of `eval` from webpack's `cheap-module-eval-source-map` devtool **(from below lines)** when your computer sets `NODE_ENV` to `development`. 🤓

https://github.com/xxhomey19/github-file-icon/blob/c31db79dac4f550ecb0db5bcf5ad52950010b14f/webpack.config.js#L96-L98

---

However, it still has 1 `eval` in `contentscript.bundle.js`.

```js
g = g || Function("return this")() || (1,eval)("this");
```

We probably need webpack/webpack#5627 to be resolved, I guess. 🤔