### PR TITLE
Fix GitHub filename selector

### DIFF
--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -9,7 +9,7 @@ const getSelector = () => {
   switch (window.location.hostname) {
     case 'github.com':
       return {
-        filenameSelector: 'tr.js-navigation-item > td.content > span > a',
+        filenameSelector: 'tr.js-navigation-item > td.content > span a',
         iconSelector: 'tr.js-navigation-item > td.icon',
         host: 'github',
       };


### PR DESCRIPTION
Fix #27

---

Normally the DOM looks like this:
![image](https://user-images.githubusercontent.com/15273128/36932775-a936eade-1f11-11e8-91d1-9cf394f876e1.png)

However, when it comes to git submodule, the DOM looks like this:
![image](https://user-images.githubusercontent.com/15273128/36932818-7afaa024-1f12-11e8-842f-8c1d77b2d1ae.png)

So I removed `>` selector.