### PR TITLE
Add option to disable icon colors

### DIFF
--- a/src/css/options.css
+++ b/src/css/options.css
@@ -1,0 +1,26 @@
+.wrapper {
+  width: 90vw;
+  max-width: 400px;
+  margin: 50px auto;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+header img {
+  width: 24px;
+  height: 24px;
+  margin-right: 8px;
+}
+
+label {
+  display: block;
+  margin: 8px 0;
+}
+
+footer {
+  margin-top: 32px;
+}

--- a/src/css/options.css
+++ b/src/css/options.css
@@ -24,3 +24,14 @@ label {
 footer {
   margin-top: 32px;
 }
+
+p.message {
+  display: inline-block;
+  vertical-align: center;
+  margin: 0;
+  margin-left: 8px;
+}
+
+p.message:empty {
+  display: none;
+}

--- a/src/css/options.css
+++ b/src/css/options.css
@@ -1,3 +1,9 @@
+body {
+  font-family: system-ui, sans-serif;
+  font-size: 75%;
+  color: #333;
+}
+
 .wrapper {
   width: 90vw;
   max-width: 400px;

--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -5,6 +5,8 @@ import '../css/icons.css';
 const select = document.querySelector.bind(document);
 select.all = document.querySelectorAll.bind(document);
 
+let colorsEnabled = true;
+
 const getSelector = () => {
   switch (window.location.hostname) {
     case 'github.com':
@@ -85,7 +87,9 @@ const update = () => {
         iconDom.classList.contains('octicon-file-directory') ||
         iconDom.classList.contains('fa-folder');
 
-      const className = fileIcons.getClassWithColor(filename);
+      const className = colorsEnabled
+        ? fileIcons.getClassWithColor(filename)
+        : fileIcons.getClass(filename);
 
       if (className && !isDirectory) {
         const icon = document.createElement('span');
@@ -119,4 +123,7 @@ const init = () => {
   document.addEventListener('pjax:end', observeFragment);
 };
 
-init();
+chrome.storage.sync.get('colorsEnabled', result => {
+  colorsEnabled = result.colorsEnabled || result.colorsEnabled === undefined;
+  init();
+});

--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -5,7 +5,7 @@ import '../css/icons.css';
 const select = document.querySelector.bind(document);
 select.all = document.querySelectorAll.bind(document);
 
-let colorsEnabled = true;
+let colorsDisabled = true;
 
 const getSelector = () => {
   switch (window.location.hostname) {
@@ -87,9 +87,9 @@ const update = () => {
         iconDom.classList.contains('octicon-file-directory') ||
         iconDom.classList.contains('fa-folder');
 
-      const className = colorsEnabled
-        ? fileIcons.getClassWithColor(filename)
-        : fileIcons.getClass(filename);
+      const className = colorsDisabled
+        ? fileIcons.getClass(filename)
+        : fileIcons.getClassWithColor(filename);
 
       if (className && !isDirectory) {
         const icon = document.createElement('span');
@@ -123,7 +123,8 @@ const init = () => {
   document.addEventListener('pjax:end', observeFragment);
 };
 
-chrome.storage.sync.get('colorsEnabled', result => {
-  colorsEnabled = result.colorsEnabled || result.colorsEnabled === undefined;
+chrome.storage.sync.get('colorsDisabled', result => {
+  // eslint-disable-next-line prefer-destructuring
+  colorsDisabled = (result || {}).colorsDisabled;
   init();
 });

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -1,0 +1,1 @@
+import '../css/options.css';

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -1,1 +1,14 @@
 import '../css/options.css';
+
+const form = document.querySelector('form');
+
+chrome.storage.sync.get('colorsEnabled', result => {
+  form.colors.checked = Boolean(result.colorsEnabled);
+});
+
+form.addEventListener('submit', e => {
+  e.preventDefault();
+
+  const colorsEnabled = form.colors.checked;
+  chrome.storage.sync.set({ colorsEnabled });
+});

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -12,20 +12,19 @@ function showMessage(message, duration) {
   }
 }
 
-chrome.storage.sync.get('colorsEnabled', result => {
-  $form.colors.checked =
-    result.colorsEnabled || result.colorsEnabled === undefined;
+chrome.storage.sync.get('colorsDisabled', result => {
+  $form.colors.checked = !(result || {}).colorsDisabled;
 });
 
 $form.addEventListener('submit', e => {
   e.preventDefault();
 
-  const colorsEnabled = $form.colors.checked;
+  const colorsDisabled = !$form.colors.checked;
 
   showMessage('Saving...');
   $form.save.disabled = true;
 
-  chrome.storage.sync.set({ colorsEnabled }, () => {
+  chrome.storage.sync.set({ colorsDisabled }, () => {
     showMessage('Saved!', 1000);
     $form.save.disabled = false;
   });

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -13,7 +13,8 @@ function showMessage(message, duration) {
 }
 
 chrome.storage.sync.get('colorsEnabled', result => {
-  $form.colors.checked = Boolean(result.colorsEnabled);
+  $form.colors.checked =
+    result.colorsEnabled || result.colorsEnabled === undefined;
 });
 
 $form.addEventListener('submit', e => {

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -1,14 +1,31 @@
 import '../css/options.css';
 
-const form = document.querySelector('form');
+const $form = document.querySelector('form');
+const $message = document.querySelector('.message');
+
+function showMessage(message, duration) {
+  $message.textContent = message;
+  if (duration) {
+    setTimeout(() => {
+      $message.textContent = '';
+    }, duration);
+  }
+}
 
 chrome.storage.sync.get('colorsEnabled', result => {
-  form.colors.checked = Boolean(result.colorsEnabled);
+  $form.colors.checked = Boolean(result.colorsEnabled);
 });
 
-form.addEventListener('submit', e => {
+$form.addEventListener('submit', e => {
   e.preventDefault();
 
-  const colorsEnabled = form.colors.checked;
-  chrome.storage.sync.set({ colorsEnabled });
+  const colorsEnabled = $form.colors.checked;
+
+  showMessage('Saving...');
+  $form.save.disabled = true;
+
+  chrome.storage.sync.set({ colorsEnabled }, () => {
+    showMessage('Saved!', 1000);
+    $form.save.disabled = false;
+  });
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,5 +28,5 @@
   },
   "content_security_policy": "script-src 'self'; object-src 'self'",
   "web_accessible_resources": ["*.woff2"],
-  "permissions": ["*://github.com/*", "tabs", "webNavigation"]
+  "permissions": ["*://github.com/*", "storage", "tabs", "webNavigation"]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,6 +21,11 @@
     "48": "img/icon-48.png",
     "128": "img/icon-128.png"
   },
+  "options_ui": {
+    "page": "options.html",
+    "chrome_style": true,
+    "open_in_tab": true
+  },
   "content_security_policy": "script-src 'self'; object-src 'self'",
   "web_accessible_resources": ["*.woff2"],
   "permissions": ["*://github.com/*", "tabs", "webNavigation"]

--- a/src/options.html
+++ b/src/options.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+  </head>
+
+  <body>
+    <h1>Options Page</h1>
+  </body>
+</html>

--- a/src/options.html
+++ b/src/options.html
@@ -17,7 +17,8 @@
       </label>
 
       <footer>
-        <button>Save</button>
+        <button name="save">Save</button>
+        <p class="message"></p>
       </footer>
     </form>
   </body>

--- a/src/options.html
+++ b/src/options.html
@@ -12,7 +12,7 @@
       </header>
 
       <label>
-        <input type="checkbox" name="colors" checked class="js-colors">
+        <input type="checkbox" name="colors" class="js-colors">
         Enable icon colors
       </label>
 

--- a/src/options.html
+++ b/src/options.html
@@ -12,7 +12,7 @@
       </header>
 
       <label>
-        <input type="checkbox" name="colors" class="js-colors">
+        <input type="checkbox" name="colors" checked class="js-colors">
         Enable icon colors
       </label>
 

--- a/src/options.html
+++ b/src/options.html
@@ -5,6 +5,20 @@
   </head>
 
   <body>
-    <h1>Options Page</h1>
+    <form action="#" class="wrapper">
+      <header>
+        <img src="img/icon-48.png" alt="GitHub File Icon Logo">
+        <h1>GitHub File Icon Options</h1>
+      </header>
+
+      <label>
+        <input type="checkbox" name="colors" class="js-colors">
+        Enable icon colors
+      </label>
+
+      <footer>
+        <button>Save</button>
+      </footer>
+    </form>
   </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ const options = {
   entry: {
     contentscript: path.join(__dirname, 'src', 'js', 'contentscript.js'),
     background: path.join(__dirname, 'src', 'js', 'background.js'),
+    options: path.join(__dirname, 'src', 'js', 'options.js'),
   },
   output: {
     path: path.join(__dirname, 'build'),
@@ -90,6 +91,11 @@ const options = {
       template: path.join(__dirname, 'src', 'background.html'),
       filename: 'background.html',
       chunks: ['background'],
+    }),
+    new HtmlWebpackPlugin({
+      template: path.join(__dirname, 'src', 'options.html'),
+      filename: 'options.html',
+      chunks: ['options'],
     }),
     new WriteFilePlugin(),
     new ExtractTextPlugin('[name].css'),


### PR DESCRIPTION
Resolves #10 

This PR creates an options page for the extension wherein the colors can be toggled.

The options page looks like this:

![options](https://user-images.githubusercontent.com/1428598/37555489-c0173242-2a22-11e8-8fc0-98b5389d7711.png)

And the file list icons with disabled colors look like this:

![no-colors](https://user-images.githubusercontent.com/1428598/37555492-d3764d46-2a22-11e8-8646-6b6f5cf3d837.png)
