### PR TITLE
Better options page

### DIFF
--- a/src/css/options.css
+++ b/src/css/options.css
@@ -1,13 +1,11 @@
 body {
   font-family: system-ui, sans-serif;
-  font-size: 75%;
   color: #333;
 }
 
 .wrapper {
   width: 90vw;
   max-width: 400px;
-  margin: 50px auto;
 }
 
 header {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,8 +23,7 @@
   },
   "options_ui": {
     "page": "options.html",
-    "chrome_style": true,
-    "open_in_tab": true
+    "chrome_style": true
   },
   "content_security_policy": "script-src 'self'; object-src 'self'",
   "web_accessible_resources": ["*.woff2"],

--- a/src/options.html
+++ b/src/options.html
@@ -7,8 +7,7 @@
   <body>
     <form action="#" class="wrapper">
       <header>
-        <img src="img/icon-48.png" alt="GitHub File Icon Logo">
-        <h1>GitHub File Icon Options</h1>
+        <h1>Options</h1>
       </header>
 
       <label>


### PR DESCRIPTION
Hello @xxhomey19 
Love the new feature. Here what I think is a little improvement.

I removed the ```open_in_tab``` that according to https://developer.chrome.com/extensions/optionsV2#step-1 is deprecated on Chrome, and in Firefox is simply very ugly. Then I cleaned up the options page layout, deleting the redundant title. 

| Before on Chrome| After on Chrome |
| -- | -- |
| <img width="370" alt="before - chrome - final" src="https://user-images.githubusercontent.com/6209647/37648271-ce921e14-2c2e-11e8-92a3-6ad8e1e44fc5.png"> | <img width="397" alt="after - chrome - final" src="https://user-images.githubusercontent.com/6209647/37648268-ce1132f4-2c2e-11e8-9576-d8b016602d24.png"> |

| Before on Firefox| After on Firefox |
| -- | -- |
| <img width="660" alt="before - firefox - final" src="https://user-images.githubusercontent.com/6209647/37648272-cf18e782-2c2e-11e8-8c9d-820511dc4fec.png"> | <img width="639" alt="after - firefox - final" src="https://user-images.githubusercontent.com/6209647/37648270-ce462e00-2c2e-11e8-9e59-f384d3303821.png"> |

Note that the 'before' screens refer to the extension without ```open_in_tab```

Tested on Firefox 59.0.1 and Chrome 65