### PR TITLE
allow icons to be set on private gitlab instances

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,5 +1,5 @@
 const githubRegexp = /.*:\/\/github.com\/.*/i;
-const gitlabRegexp = /.*:\/\/gitlab.com\/.*/i;
+const gitlabRegexp = /.*:\/\/.*gitlab.*./i;
 const bitbucketRegexp = /.*:\/\/bitbucket.org\/.*/i;
 const gogsRegexp = /.*:\/\/.*.gogs.io\/.*/i;
 const giteaRegexp = /.*:\/\/.*.gitea.io\/.*/i;

--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -7,9 +7,21 @@ import '../css/icons.css';
 let colorsDisabled = false;
 let darkMode = false;
 
+const getSiteInstance = hostname => {
+  if (hostname.match(/.*github.*./i)) {
+    return 'github';
+  } else if (hostname.match(/.*bitbucket.org/i)) {
+    return 'bitbucket';
+  } else if (hostname.match(/.*gitlab.*./i)) {
+    return 'gitlab';
+  } else {
+    return 'other';
+  }
+};
+
 const getSelector = hostname => {
-  switch (hostname) {
-    case 'github.com':
+  switch (getSiteInstance(hostname)) {
+    case 'github':
       return {
         filenameSelector:
           'tr.js-navigation-item > td.content > span a, .files-list > a.list-item',
@@ -17,17 +29,17 @@ const getSelector = hostname => {
           'tr.js-navigation-item > td.icon, .files-list > a.list-item',
         host: 'github',
       };
-    case 'gitlab.com':
-      return {
-        filenameSelector: 'tr.tree-item > td.tree-item-file-name',
-        iconSelector: 'tr.tree-item > td.tree-item-file-name > i',
-        host: 'gitlab',
-      };
-    case 'bitbucket.org':
+    case 'bitbucket':
       return {
         filenameSelector: 'tr.iterable-item > td.filename > div > a',
         iconSelector: 'tr.iterable-item > td.filename > div > a > span',
         host: 'bitbucket',
+      };
+    case 'gitlab':
+      return {
+        filenameSelector: 'tr.tree-item > td.tree-item-file-name',
+        iconSelector: 'tr.tree-item > td.tree-item-file-name > i',
+        host: 'gitlab',
       };
     default:
       return {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,11 +9,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://github.com/*",
-        "https://gitlab.com/*",
-        "https://bitbucket.org/*",
-        "https://*.gogs.io/*",
-        "https://*.gitea.io/*"
+        "*://*/*"
       ],
       "js": ["contentscript.bundle.js"],
       "css": ["contentscript.css"],


### PR DESCRIPTION
GitLab is often run on private server instances. These modifications allow this extension to work on GitLab instances which are not gitlab.com