### PR TITLE
Add support for self-hosted GitHub and GitLab environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "file-icons-js": "^1.0.3",
     "is-mobile": "^2.0.0",
     "select-dom": "^4.1.3",
+    "webext-domain-permission-toggle": "^1.0.0",
+    "webext-dynamic-content-scripts": "^6.0.1",
     "webext-options-sync": "^0.15.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "is-mobile": "^2.0.0",
     "select-dom": "^4.1.3",
     "webext-domain-permission-toggle": "^1.0.0",
-    "webext-dynamic-content-scripts": "^6.0.1",
+    "webext-dynamic-content-scripts": "^6.0.2",
     "webext-options-sync": "^0.15.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "is-mobile": "^2.0.0",
     "select-dom": "^4.1.3",
     "webext-domain-permission-toggle": "^1.0.0",
-    "webext-dynamic-content-scripts": "^6.0.2",
+    "webext-dynamic-content-scripts": "^6.0.3-0",
     "webext-options-sync": "^0.15.2"
   },
   "devDependencies": {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,21 +1,5 @@
-const githubRegexp = /.*:\/\/github.com\/.*/i;
-const gitlabRegexp = /.*:\/\/gitlab.com\/.*/i;
-const bitbucketRegexp = /.*:\/\/bitbucket.org\/.*/i;
-const gogsRegexp = /.*:\/\/.*.gogs.io\/.*/i;
-const giteaRegexp = /.*:\/\/.*.gitea.io\/.*/i;
-
-const isGit = url =>
-  url.match(githubRegexp) !== null ||
-  url.match(gitlabRegexp) !== null ||
-  url.match(bitbucketRegexp) !== null ||
-  url.match(gogsRegexp) !== null ||
-  url.match(giteaRegexp) !== null;
-
-chrome.webNavigation.onHistoryStateUpdated.addListener(({ url }) => {
-  if (isGit(url)) {
-    chrome.tabs.executeScript(null, { file: 'content.bundle.js' });
-  }
-});
+import 'webext-dynamic-content-scripts';
+import addDomainPermissionToggle from 'webext-domain-permission-toggle';
 
 chrome.contextMenus.create({
   id: 'change-icon-color',
@@ -42,6 +26,8 @@ chrome.contextMenus.create({
     'https://*.gitea.io/*',
   ],
 });
+
+addDomainPermissionToggle();
 
 const toggleStorage = key => tabs => {
   const activeTab = tabs[0];

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,7 +41,7 @@
     "https://*.gogs.io/*",
     "https://*.gitea.io/*"
   ],
-	"optional_permissions": [
+  "optional_permissions": [
     "http://*/*",
     "https://*/*"
   ]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -31,8 +31,6 @@
   "permissions": [
     "contextMenus",
     "storage",
-    "tabs",
-    "webNavigation",
     "https://github.com/*",
     "https://gitlab.com/*",
     "https://bitbucket.org/*",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,15 +26,23 @@
     "64": "img/icon-64.png",
     "128": "img/icon-128.png"
   },
+  "browser_action": {
+    "default_icon": "img/icon-64.png"
+  },
   "content_security_policy": "script-src 'self'; object-src 'self'",
   "web_accessible_resources": ["*.woff2"],
   "permissions": [
     "contextMenus",
     "storage",
+    "activeTab",
     "https://github.com/*",
     "https://gitlab.com/*",
     "https://bitbucket.org/*",
     "https://*.gogs.io/*",
     "https://*.gitea.io/*"
+  ],
+	"optional_permissions": [
+    "http://*/*",
+    "https://*/*"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -662,6 +662,30 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@types/chrome@0.0.86":
+  version "0.0.86"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.86.tgz#1026ef8e76db4fde1859cae858d73236fe670d69"
+  integrity sha512-7ehebPf/5IR64SYdD2Vig0q0oUCNbWMQ29kASlNJaHVVtA5/J/DnrxnYVPCID70o7LgHdYsav6I4/XdqAxjTLQ==
+  dependencies:
+    "@types/filesystem" "*"
+
+"@types/filesystem@*":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.29.tgz#ee3748eb5be140dcf980c3bd35f11aec5f7a3748"
+  integrity sha512-85/1KfRedmfPGsbK8YzeaQUyV1FQAvMPMTuWFQ5EkLd2w7szhNO96bk3Rh/SKmOfd9co2rCLf0Voy4o7ECBOvw==
+  dependencies:
+    "@types/filewriter" "*"
+
+"@types/filewriter@*":
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.28.tgz#c054e8af4d9dd75db4e63abc76f885168714d4b3"
+  integrity sha1-wFTor02d11205jq8dviFFocU1LM=
+
+"@types/firefox-webext-browser@^67.0.2":
+  version "67.0.2"
+  resolved "https://registry.yarnpkg.com/@types/firefox-webext-browser/-/firefox-webext-browser-67.0.2.tgz#04625d3294fbca54bccf42dae43f636c5b6452a2"
+  integrity sha512-tXR5THtH5Fqwfmi4y/2dTxCTebqHsKCH2bif/VdE5CPcB/S5x5fu+N+wBuMENzN41agovHMU/LQbtWNV+Aux+w==
+
 "@webassemblyjs/ast@1.7.11":
   version "1.7.11"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.7.11.tgz#b988582cafbb2b095e8b556526f30c90d057cace"
@@ -1680,6 +1704,13 @@ constants-browserify@^1.0.0:
 contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+
+content-scripts-register-polyfill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/content-scripts-register-polyfill/-/content-scripts-register-polyfill-1.0.0.tgz#21bc2df475ea48aa83737d24675a6a44e4a006a7"
+  integrity sha512-DiHscMTyL5evEg6C8GSkkd5Kfkma726zxqIt+zv6L2W/gVqYOUZUw2F27BpAUp9nQZnIrky5Gx1eYA9Fw4+aeA==
+  dependencies:
+    "@types/firefox-webext-browser" "^67.0.2"
 
 convert-source-map@^1.1.0:
   version "1.6.0"
@@ -6612,9 +6643,38 @@ watchpack@^1.5.0:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
+webext-additional-permissions@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/webext-additional-permissions/-/webext-additional-permissions-0.1.0.tgz#bc5a2a6cb8e60098c81a6004c446bfae2aefd85a"
+  integrity sha512-eA1o6BdRbpU5ClL6GcmwhGtVVzNTbQSqX9esakpurWYVt9ykpGQ1ZNe5l30Yt19GW0eRC8VdroOeJSumP5cMpQ==
+  dependencies:
+    "@types/chrome" "0.0.86"
+
+webext-domain-permission-toggle@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/webext-domain-permission-toggle/-/webext-domain-permission-toggle-1.0.0.tgz#6f9a6d3234ffe596921d1be5ae8823ef5b02ebd2"
+  integrity sha512-K6RAOYtVCMAmqjQPopMbGOIoxpFU05ERGgaLkUNvFCdpPsXLB5y4m1+Cq1dezyfx6FU0lLEqxoL/5/49+EY5zA==
+  dependencies:
+    webext-additional-permissions "^0.1.0"
+
+webext-dynamic-content-scripts@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-6.0.1.tgz#00772648a90e68db2e24609e256b87a4363f3a63"
+  integrity sha512-e0OchJSb1fiwscqVY5Fy5wHYgwY4hLnfdDhnNBFFj91v0gQhVPCyXYxqAO+HAEiqAfaU7NzluFjssfshccfN5Q==
+  dependencies:
+    "@types/chrome" "0.0.86"
+    content-scripts-register-polyfill "^1.0.0"
+    webext-additional-permissions "^0.1.0"
+    webext-permissions-events-polyfill "^1.0.1"
+
 webext-options-sync@^0.15.2:
   version "0.15.2"
   resolved "https://registry.yarnpkg.com/webext-options-sync/-/webext-options-sync-0.15.2.tgz#e846eda8b0981cabf2e5d4656fcac0a1cb139415"
+
+webext-permissions-events-polyfill@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/webext-permissions-events-polyfill/-/webext-permissions-events-polyfill-1.0.1.tgz#c5108d140b03efbd06b34c7211694b8cde928177"
+  integrity sha512-dPsU7KtDn+OG+mPy0LLc9UhMXdVeQ8ywD5kK1GFtvceur4IWOnpI5D4uTjMPrKm8+re/8cbHKwVjnviIA9wZ3Q==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6657,10 +6657,10 @@ webext-domain-permission-toggle@^1.0.0:
   dependencies:
     webext-additional-permissions "^0.1.0"
 
-webext-dynamic-content-scripts@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-6.0.2.tgz#6f70916a104ac7c89364c4883be2ff766c165d95"
-  integrity sha512-8X2yqLPjP8jLMdCMLz/QXVkipt9H9J1kitUoG8S9O03urQnsRvduXnkmfpTZnNajr0q2mn5DN6ReXMZOp87vUw==
+webext-dynamic-content-scripts@^6.0.3-0:
+  version "6.0.3-0"
+  resolved "https://registry.yarnpkg.com/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-6.0.3-0.tgz#ea36d278f338cb7b7d38476a633b909f7ecea45f"
+  integrity sha512-6qWp+SJtrnAFv2E1HyZW+3wYNPm/tbltjtds1zKpIp8cbEwMFjc7c4VepIJmMclZGuPm0AMVunIjgbCwwF7Psg==
   dependencies:
     "@types/chrome" "0.0.86"
     content-scripts-register-polyfill "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6657,10 +6657,10 @@ webext-domain-permission-toggle@^1.0.0:
   dependencies:
     webext-additional-permissions "^0.1.0"
 
-webext-dynamic-content-scripts@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-6.0.1.tgz#00772648a90e68db2e24609e256b87a4363f3a63"
-  integrity sha512-e0OchJSb1fiwscqVY5Fy5wHYgwY4hLnfdDhnNBFFj91v0gQhVPCyXYxqAO+HAEiqAfaU7NzluFjssfshccfN5Q==
+webext-dynamic-content-scripts@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-6.0.2.tgz#6f70916a104ac7c89364c4883be2ff766c165d95"
+  integrity sha512-8X2yqLPjP8jLMdCMLz/QXVkipt9H9J1kitUoG8S9O03urQnsRvduXnkmfpTZnNajr0q2mn5DN6ReXMZOp87vUw==
   dependencies:
     "@types/chrome" "0.0.86"
     content-scripts-register-polyfill "^1.0.0"


### PR DESCRIPTION
Closes https://github.com/xxhomey19/github-file-icon/issues/2
Closes https://github.com/xxhomey19/github-file-icon/issues/55

Implemented like in Refined GitHub.

I skipped the tests because:

1. They seem to also test what's already being taken care by these new modules
2. Jest is failing on this, even though babel seems to be already configured:

```

    Jest encountered an unexpected token

    This usually means that you are trying to import a file which Jest cannot parse, e.g. it's not plain JavaScript.

    By default, if Jest sees a Babel config, it will use that to transform your files, ignoring "node_modules".

    Here's what you can do:
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/en/configuration.html

    Details:

    /Users/bfred/Web/Gitbase/github-file-icon/node_modules/webext-dynamic-content-scripts/index.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){import 'content-scripts-register-polyfill';
                                                                                             ^^^^^^

    SyntaxError: Unexpected token import

    > 1 | import 'webext-dynamic-content-scripts';
        | ^
      2 | import addDomainPermissionToggle from 'webext-domain-permission-toggle';
```